### PR TITLE
Fix exercise 28 getYear

### DIFF
--- a/index.html
+++ b/index.html
@@ -3344,7 +3344,7 @@
 			function(pricesNASDAQ, printRecord) {
 				var microsoftPrices,
 					now = new Date(),
-					tenDaysAgo = new Date( now.getYear(), now.getMonth(), now.getDate() - 10);
+					tenDaysAgo = new Date( now.getFullYear(), now.getMonth(), now.getDate() - 10);
 
 				// use filter() to filter the trades for MSFT prices recorded any time after 10 days ago
 				microsoftPrices =
@@ -3406,7 +3406,7 @@
 			function(pricesNASDAQ, printRecord) {
 				var microsoftPrices,
 					now = new Date(),
-					tenDaysAgo = new Date( now.getYear(), now.getMonth(), now.getDate() - 10);
+					tenDaysAgo = new Date( now.getFullYear(), now.getMonth(), now.getDate() - 10);
 
 				// use filter() to filter the trades for MSFT prices recorded any time after 10 days ago
 				microsoftPrices =


### PR DESCRIPTION
On exercise 28, `now.getYear()` is used to generate `tenDaysAgo` var.
It return 114, resulting in a `tenDaysAgo` actually 1900 years ago :)
