### PR TITLE
Fix typo and reference to previous exercise

### DIFF
--- a/index.html
+++ b/index.html
@@ -2602,7 +2602,7 @@
 	<div class="lesson">
 		<h4>Exercise 23: Combine videos and bookmarks by index</h4>
 
-		<p>Let's repeat exercise 19, but this time lets use your new zip() function. For each video and bookmark pair,
+		<p>Let's repeat exercise 21, but this time lets use your new zip() function. For each video and bookmark pair,
 			create a {videoId, bookmarkId} pair.</p>
 		<textarea class="code" rows="60" cols="80">
 			function() {

--- a/index.html
+++ b/index.html
@@ -3663,7 +3663,7 @@
 				seq(              [ 1,,,2,,,3,,,4,,,5,,,6,,,7,,,8,,,9,,, ]).
 					takeUntil(seq([  ,,, {eventType: "click"},,, ]) )                    === seq([ 1,,,2 ])
 		</pre>
-		<p>Earlier we (unknowningly) built a dynamic Microsoft price stock ticker using Observable. The problem with that stock
+		<p>Earlier we (unknowingly) built a dynamic Microsoft price stock ticker using Observable. The problem with that stock
 			ticker was that <i>it kept going on forever</i>. If left unchecked, all the entries in the log could use up all of
 			the memory on the page. In the exercise below, filter the Observable sequence of NASDAQ prices for MSFT stock
 			prices, use the fromEvent() function to create an Observable .


### PR DESCRIPTION
* fix typo (unknowningly -> unknowingly)
* fix reference to previous exercise: exercise 23 references exercise 19 (which is supposed to be the last exercise that produces { videoId, bookmarkId } pair). The correct exercise to be referenced is exercise 21 instead of 19.