### PR TITLE
Fix closing bracket in example code

### DIFF
--- a/index.html
+++ b/index.html
@@ -3889,7 +3889,7 @@
 				[1,2,3].takeUntil([1])                                          === []
 
 				seq([1,,,2,,,3,,, ]).takeUntil(
-				seq([ ,,, ,,4 , }))                                             === seq([ 1,,,2 ])
+				seq([ ,,, ,,4 , ]))                                             === seq([ 1,,,2 ])
 
 			</pre>
 			<p>Remember when I <a href="#indexers">prohibited the use of array indexers?</a> The reason for that restriction should


### PR DESCRIPTION
A closing curly brace was mistakenly typed where a closing bracket
should have gone. This went unnoticed for so long because it was typo in
code that never ran.
