### PR TITLE
PR - Correct Typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -1505,7 +1505,7 @@
 					map(function(item) {
 						// ------------   INSERT CODE HERE!  ----------------------------
 						// Apply the projection function to each item. The projection
-						// function will return an new child array. This will create a
+						// function will return a new child array. This will create a
 						// two-dimensional array.
 						// ------------   INSERT CODE HERE!  ----------------------------
 					}).
@@ -1864,7 +1864,7 @@
 	<div class="lesson">
 		<h4>Exercise 16: Implement reduce()</h4>
 
-		<p>Let's add a reduce() function to the Array type. Like map. Take note this is <b>different from the reduce in ES5</b>, which returns an value instead of an Array! </p>
+		<p>Let's add a reduce() function to the Array type. Like map. Take note this is <b>different from the reduce in ES5</b>, which returns a value instead of an Array! </p>
 		<textarea class="code" rows="40" cols="80">
 			// [1,2,3].reduce(function(accumulatedValue, currentValue) { return accumulatedValue + currentValue; }); === [6];
 			// [1,2,3].reduce(function(accumulatedValue, currentValue) { return accumulatedValue + currentValue; }, 10); === [16];


### PR DESCRIPTION
Exercise 16: "an value instead of an array" should say "a value instead of an array"
Exercise 13: "an new child array" should say "a new child array"
