### PR TITLE
Changed RxJS version from latest to 5.5.10

### DIFF
--- a/index.html
+++ b/index.html
@@ -5040,7 +5040,7 @@
 <script src="assets/codemirror/matchbrackets.js"></script>
 <script src="assets/app/javascript.js"></script>
 
-<script src="https://unpkg.com/@reactivex/rxjs/dist/global/Rx.js"></script>
+<script src="https://unpkg.com/@reactivex/rxjs@5.5.10/dist/global/Rx.js"></script>
 
 <script src="assets/jquery/jquery-1.10.2.min.js"></script>
 <script src="assets/bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
The latest version of RxJS has been bumped to 6 on npm. The library on unpkg.com is now resolving to a file that doesn't exist so fixing the version to 5.5.10 

Might be better to reference RxJS v6, but not sure if the tutorial would support the upgrade.