### PR TITLE
[Duplicate] Load fifth version of rxjs explicitly from unpkg

### DIFF
--- a/index.html
+++ b/index.html
@@ -5040,7 +5040,7 @@
 <script src="assets/codemirror/matchbrackets.js"></script>
 <script src="assets/app/javascript.js"></script>
 
-<script src="https://unpkg.com/@reactivex/rxjs/dist/global/Rx.js"></script>
+<script src="https://unpkg.com/@reactivex/rxjs@5.5.10/dist/global/Rx.js"></script>
 
 <script src="assets/jquery/jquery-1.10.2.min.js"></script>
 <script src="assets/bootstrap/js/bootstrap.min.js"></script>


### PR DESCRIPTION
Recently rxjs has been updated to version 6. So old url doesn't work anymore. And because of that 3rd exercise doesn't work too. I explicitly include 5th version, because upgrade up to 6th version requires more time...