### PR TITLE
Fix TypeError on the console from Exercise 29

### DIFF
--- a/index.html
+++ b/index.html
@@ -3555,20 +3555,20 @@
 
 		<p>Subscribing to an Event and traversing an Array are fundamentally the same operation. The only difference is that
 			<b>Array traversal is synchronous and completes, and Event traversal is asynchronous and <u>never completes</u>.</b>
-			If we convert a button click Event to an Observable object, we can use forEach() to traverse the Event.</p>
+			If we convert a button click Event to an Observable object, we can use do() to traverse the Event.</p>
 		<textarea class="code" rows="60" cols="80">
 			function(button) {
 				var buttonClicks = Observable.fromEvent(button, "click");
 
-				// In the case of an Observable, forEach returns a subscription object.
 				var subscription =
 					buttonClicks.
-						forEach(function(clickEvent) {
+						do(function(clickEvent) {
 							alert("Button was clicked. Stopping Traversal.");
 
 							// Stop traversing the button clicks
-							subscription.dispose();
-						});
+							subscription.unsubscribe();
+						}).
+						subscribe();
 			}
 		</textarea>
 		<button class="go">Run</button>


### PR DESCRIPTION
**Proposed changes**
1. `Observable.prototype.forEach` returns a `Promise`. This causes the original example code to throw a `TypeError` when `subscription.dispose` is not found. Switching from `forEach` to `do` solves this issue.
2. As of RxJS v5, [subscription `dispose` is now `unsubscribe`](https://github.com/ReactiveX/rxjs/blob/5.x/MIGRATION.md#subscription-dispose-is-now-unsubscribe).

This PR will close #160.

**Demo**
There is no error on the console. 🎉 
![reactivex - learnrx - fixes 160](https://user-images.githubusercontent.com/2585460/53998480-db3b7d00-410d-11e9-9bfb-6ee14088e48f.gif)



**CC**: @morenoh149