### PR TITLE
Fix problems with Exercise 37

### DIFF
--- a/index.html
+++ b/index.html
@@ -4537,7 +4537,7 @@
 										}),
 									getJSON("http://api-global.netflix.com/" + abTestInformation.urlPrefix + "/movieLists"),
 									function(queue, movieListsMessage) {
-										var copyOfMovieLists = Object.create(movieListsMessage.list);
+										var copyOfMovieLists = [].concat(movieListsMessage.list);
 										if (queue !== undefined) {
 											copyOfMovieLists.push(queue);
 										}
@@ -4551,13 +4551,15 @@
 						});
 
 				movieListsSequence.
-					forEach(
+					do(
 						function(movieLists) {
 							showMovieLists(movieLists);
 						},
 						function(err) {
 							showError(err);
-						});
+						}
+					).
+					subscribe();
 			}
 		</textarea>
 		<button class="go">Run</button>
@@ -4577,16 +4579,16 @@
 											// If client is still interested in the results, send them.
 											if (subscribed) {
 												// Send data to the client
-												observer.onNext(data);
+												observer.next(data);
 												// Immediately complete the sequence
-												observer.onCompleted();
+												observer.complete();
 											}
 										},
 									error: function(ex) {
 										// If client is still interested in the results, send them.
 										if (subscribed) {
 											// Inform the client that an error occurred.
-											observer.onError(ex);
+											observer.error(ex);
 										}
 									}
 								});
@@ -4602,8 +4604,10 @@
 				fun(
 					{
 						addEventListener: function(event, handler) {
-							window.setTimeout(handler, 200)
-						},
+							window.setTimeout(function(){
+								var fakeEvent = { preventDefault: NOOP };
+								handler(fakeEvent);
+						}, 200);						},
 						removeEventListener: NOOP
 					},
 					getJSON,


### PR DESCRIPTION
**Proposed changes**
1. Switch from `forEach` to `do` because `forEach` actually returns a `Promise`. When it resolved it would call `showMovieLists` with unexpected results.
2. Change to the v5 callback names for `onNext`, `onError`, and `onCompleted`.
3. Send a fake event to the `load` event listener to prevent a `TypeError`.
4. Replace `Object.create` with `[].concat` to keep the elements of `movieListsMessage.list` int eh result.

<br>

**Demo**
![reactivex - learnrx - fixes 177](https://user-images.githubusercontent.com/2585460/53998985-bd6f1780-410f-11e9-8754-026630c70d59.gif)

This PR will close issue #177.
